### PR TITLE
🔧 cloud runのv2への移行 / memory limitを設定

### DIFF
--- a/envs/dev/cloudrun.tf
+++ b/envs/dev/cloudrun.tf
@@ -1,32 +1,33 @@
-resource "google_cloud_run_service" "cloudrun-dev-main-backend" {
+resource "google_cloud_run_v2_service" "cloudrun-dev-main-backend" {
   name     = "dev-main-backend"
   location = var.region
 
   template {
-    spec {
-      containers {
-        name  = "nginx"
-        image = "asia-northeast1-docker.pkg.dev/${var.project_id}/dev-main/nginx:latest"
-        ports {
-          container_port = 80
+    containers {
+      name  = "nginx"
+      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/dev-main/nginx:latest"
+      ports {
+        container_port = 80
+      }
+      resources {
+        limits = {
+          "memory" = "1024Mi"
         }
       }
+    }
 
-
-      containers {
-        name  = "backend"
-        image = "asia-northeast1-docker.pkg.dev/${var.project_id}/dev-main/backend:latest"
-        env {
-          name  = "PORT"
-          value = "8080"
-        }
+    containers {
+      name  = "backend"
+      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/dev-main/backend:latest"
+      env {
+        name  = "PORT"
+        value = "8080"
       }
     }
   }
 
   traffic {
-    percent         = 100
-    latest_revision = true
+    percent = 100
   }
 }
 
@@ -40,9 +41,9 @@ data "google_iam_policy" "noauth" {
 }
 
 resource "google_cloud_run_service_iam_policy" "noauth" {
-  location = google_cloud_run_service.cloudrun-dev-main-backend.location
-  project  = google_cloud_run_service.cloudrun-dev-main-backend.project
-  service  = google_cloud_run_service.cloudrun-dev-main-backend.name
+  location = google_cloud_run_v2_service.cloudrun-dev-main-backend.location
+  project  = google_cloud_run_v2_service.cloudrun-dev-main-backend.project
+  service  = google_cloud_run_v2_service.cloudrun-dev-main-backend.name
 
   policy_data = data.google_iam_policy.noauth.policy_data
 }


### PR DESCRIPTION
表題の通り。

https://cloud.google.com/blog/ja/products/devops-sre/migrating-terraform-resources-stablely-to-cloud-run-api-version-2
